### PR TITLE
conflict in django base version btw apps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django~=3.1.7
+Django==3.2.2
 django-admin-inline-paginator~=0.1.1
 djangorestframework~=3.12.2
 drf-nested-routers~=0.93.3


### PR DESCRIPTION
while installing ensembl-prodution-service :
The conflict is caused by:
    The user requested Django==3.2.2
    ensembl-prodinf-dbcopy 1.0.0 depends on Django~=3.1.7